### PR TITLE
Fix broken zero pad implementation causing corrupted ciphertext

### DIFF
--- a/ecies_test.go
+++ b/ecies_test.go
@@ -197,3 +197,19 @@ func TestEncryptAgainstPythonVersion(t *testing.T) {
 
 	assert.Equal(t, string(plaintext), testingMessage)
 }
+
+func BenchmarkEncryptAndDecrypt(b *testing.B) {
+	privkey := NewPrivateKeyFromBytes(testingReceiverPrivkey)
+
+	for i := 0; i < b.N; i++ {
+		ciphertext, err := Encrypt(privkey.PublicKey, []byte(testingMessage))
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		_, err = Decrypt(privkey, ciphertext)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/publickey.go
+++ b/publickey.go
@@ -103,11 +103,7 @@ func NewPublicKeyFromBytes(b []byte) (*PublicKey, error) {
 // Could be optionally compressed by dropping Y part
 func (k *PublicKey) Bytes(compressed bool) []byte {
 	x := k.X.Bytes()
-	if len(x) < 32 {
-		for i := 0; i < 32-len(x); i++ {
-			x = append([]byte{0}, x...)
-		}
-	}
+	x = zeroPad(x, 32)
 
 	if compressed {
 		// If odd
@@ -120,11 +116,7 @@ func (k *PublicKey) Bytes(compressed bool) []byte {
 	}
 
 	y := k.Y.Bytes()
-	if len(y) < 32 {
-		for i := 0; i < 32-len(y); i++ {
-			y = append([]byte{0}, y...)
-		}
-	}
+	y = zeroPad(y, 32)
 
 	return bytes.Join([][]byte{{0x04}, x, y}, nil)
 }

--- a/utils.go
+++ b/utils.go
@@ -18,10 +18,12 @@ func kdf(secret []byte) (key []byte, err error) {
 	return key, nil
 }
 
-func zeroPad(b []byte, leigth int) []byte {
-	for i := 0; i < leigth-len(b); i++ {
-		b = append([]byte{0x00}, b...)
+func zeroPad(b []byte, length int) []byte {
+	if len(b) > length {
+		panic("bytes too long")
 	}
-
+	if len(b) < length {
+		b = append(make([]byte, length-len(b)), b...)
+	}
 	return b
 }


### PR DESCRIPTION
This is a fix for #86, which was mainly caused by a broken zeroPad function as well as equally buggy equivalent code present in publickey.go. An additional on-curve check was also added, as well as a benchmark test that would have made the bug easier to identify.